### PR TITLE
Add parameters modification UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(ament_cmake REQUIRED)
 
 set(dependencies_pkgs
   rclcpp
+  rcl_interfaces
   std_msgs
   rviz_common
   Qt5Core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(dependencies_pkgs
   rclcpp
   rcl_interfaces
   std_msgs
+  std_srvs
   rviz_common
   Qt5Core
   Qt5Gui

--- a/include/curobo_rviz/curobo_rviz.hpp
+++ b/include/curobo_rviz/curobo_rviz.hpp
@@ -49,5 +49,6 @@ namespace curobo_rviz
     std::shared_ptr<std_srvs::srv::Trigger::Request> motion_gen_config_request_;
     int max_attempts_;
     float timeout_, time_dilation_factor_, voxel_size_, collision_activation_distance_;
+    QTimer *timerConfirmChangesMessage_;
   };
 } // curobo_rviz

--- a/include/curobo_rviz/curobo_rviz.hpp
+++ b/include/curobo_rviz/curobo_rviz.hpp
@@ -45,6 +45,8 @@ namespace curobo_rviz
     std::unique_ptr<Ui::gui> ui_;
     rclcpp::Node::SharedPtr node_;
     rclcpp::SyncParametersClient::SharedPtr param_client_;
+    rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr motion_gen_config_client_;
+    std::shared_ptr<std_srvs::srv::Trigger::Request> motion_gen_config_request_;
     int max_attempts_;
     float timeout_, time_dilation_factor_, voxel_size_, collision_activation_distance_;
   };

--- a/include/curobo_rviz/curobo_rviz.hpp
+++ b/include/curobo_rviz/curobo_rviz.hpp
@@ -35,10 +35,13 @@ namespace curobo_rviz
     void updateMaxAttempts(int value);
     void updateTimeout(double value);
     void updateTimeDilationFactor(double value);
+    void updateParameters();
+    void on_confirmPushButton_clicked();
 
   private:
     std::unique_ptr<Ui::gui> ui_;
     rclcpp::Node::SharedPtr node_;
+    rclcpp::SyncParametersClient::SharedPtr param_client_;
     int max_attempts_;
     float timeout_, time_dilation_factor_;
 

--- a/include/curobo_rviz/curobo_rviz.hpp
+++ b/include/curobo_rviz/curobo_rviz.hpp
@@ -36,6 +36,8 @@ namespace curobo_rviz
     void updateMaxAttempts(int value);
     void updateTimeout(double value);
     void updateTimeDilationFactor(double value);
+    void updateVoxelSize(double value);
+    void updateCollisionActivationDistance(double value);
     void updateParameters();
     void on_confirmPushButton_clicked();
 
@@ -44,12 +46,6 @@ namespace curobo_rviz
     rclcpp::Node::SharedPtr node_;
     rclcpp::SyncParametersClient::SharedPtr param_client_;
     int max_attempts_;
-    float timeout_, time_dilation_factor_;
-
-  protected:
-    std_msgs::msg::Bool msg_;
-    rclcpp::Publisher<std_msgs::msg::UInt8>::SharedPtr max_attempts_pub_;
-    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr timeout_pub_;
-    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr time_dilation_factor_pub_;
+    float timeout_, time_dilation_factor_, voxel_size_, collision_activation_distance_;
   };
 } // curobo_rviz

--- a/include/curobo_rviz/curobo_rviz.hpp
+++ b/include/curobo_rviz/curobo_rviz.hpp
@@ -5,6 +5,7 @@
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/u_int8.hpp>
 #include <std_msgs/msg/float32.hpp>
+#include <std_srvs/srv/trigger.hpp>
 // RVIZ2
 #include <rviz_common/panel.hpp>
 // Qt

--- a/resource/curobo_rviz_panel.ui
+++ b/resource/curobo_rviz_panel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>466</width>
-    <height>170</height>
+    <height>149</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,7 +19,7 @@
      <x>0</x>
      <y>10</y>
      <width>461</width>
-     <height>151</height>
+     <height>131</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
@@ -41,28 +41,18 @@
     <property name="verticalSpacing">
      <number>5</number>
     </property>
-    <item row="2" column="3" colspan="2">
-     <widget class="QPushButton" name="confirmPushButton">
-      <property name="text">
-       <string>Confirm Changes</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1">
-     <widget class="QDoubleSpinBox" name="doubleSpinBox_2">
+    <item row="3" column="1">
+     <widget class="QDoubleSpinBox" name="doubleSpinBoxTimeDilationFactor">
       <property name="maximum">
        <double>1.000000000000000</double>
       </property>
       <property name="singleStep">
        <double>0.100000000000000</double>
       </property>
-      <property name="value">
-       <double>0.000000000000000</double>
-      </property>
      </widget>
     </item>
-    <item row="1" column="4">
-     <widget class="QDoubleSpinBox" name="doubleSpinBox_4">
+    <item row="2" column="5">
+     <widget class="QDoubleSpinBox" name="doubleSpinBoxCollisionActivationDistance">
       <property name="decimals">
        <number>3</number>
       </property>
@@ -74,111 +64,8 @@
       </property>
      </widget>
     </item>
-    <item row="0" column="3">
-     <widget class="QLabel" name="label_4">
-      <property name="text">
-       <string>Voxel size</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_2">
-      <property name="text">
-       <string>Timeout</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="label_1">
-      <property name="layoutDirection">
-       <enum>Qt::LeftToRight</enum>
-      </property>
-      <property name="text">
-       <string>Max attempts</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="QSpinBox" name="spinBox_1">
-      <property name="maximum">
-       <number>10</number>
-      </property>
-      <property name="value">
-       <number>0</number>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="4">
-     <widget class="QDoubleSpinBox" name="doubleSpinBox_3">
-      <property name="maximum">
-       <double>50.000000000000000</double>
-      </property>
-      <property name="singleStep">
-       <double>0.020000000000000</double>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="3">
-     <widget class="QLabel" name="label_5">
-      <property name="text">
-       <string>Collision activation distance</string>
-      </property>
-      <property name="scaledContents">
-       <bool>false</bool>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="QDoubleSpinBox" name="doubleSpinBox_1">
-      <property name="maximum">
-       <double>60.000000000000000</double>
-      </property>
-      <property name="singleStep">
-       <double>0.500000000000000</double>
-      </property>
-      <property name="value">
-       <double>0.000000000000000</double>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="label_3">
+    <item row="3" column="0">
+     <widget class="QLabel" name="labelTimeDilationFactor">
       <property name="layoutDirection">
        <enum>Qt::LeftToRight</enum>
       </property>
@@ -196,7 +83,33 @@
       </property>
      </widget>
     </item>
-    <item row="0" column="2">
+    <item row="3" column="4" colspan="2">
+     <widget class="QPushButton" name="confirmPushButton">
+      <property name="text">
+       <string>Confirm Changes</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="4">
+     <widget class="QLabel" name="labelCollisionActivationDistance">
+      <property name="text">
+       <string>Collision activation distance</string>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="3">
      <spacer name="horizontalSpacer">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
@@ -208,6 +121,120 @@
        </size>
       </property>
      </spacer>
+    </item>
+    <item row="0" column="4" colspan="2">
+     <widget class="QLabel" name="labelUpdateOnConfirm">
+      <property name="font">
+       <font>
+        <italic>true</italic>
+        <bold>true</bold>
+        <strikeout>false</strikeout>
+        <kerning>true</kerning>
+       </font>
+      </property>
+      <property name="text">
+       <string>Update on confirm</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="5">
+     <widget class="QDoubleSpinBox" name="doubleSpinBoxVoxelSize">
+      <property name="maximum">
+       <double>50.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.020000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="labelMaxAttempts">
+      <property name="layoutDirection">
+       <enum>Qt::LeftToRight</enum>
+      </property>
+      <property name="text">
+       <string>Max attempts</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0" colspan="2">
+     <widget class="QLabel" name="labelUpdateOnChange">
+      <property name="font">
+       <font>
+        <italic>true</italic>
+        <bold>true</bold>
+        <strikeout>false</strikeout>
+        <kerning>true</kerning>
+       </font>
+      </property>
+      <property name="text">
+       <string>Update on change</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QSpinBox" name="spinBoxMaxAttempts">
+      <property name="maximum">
+       <number>10</number>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="4">
+     <widget class="QLabel" name="labelVoxelSize">
+      <property name="text">
+       <string>Voxel size</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="labelTimeout">
+      <property name="text">
+       <string>Timeout</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QDoubleSpinBox" name="doubleSpinBoxTimeout">
+      <property name="maximum">
+       <double>60.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.500000000000000</double>
+      </property>
+     </widget>
     </item>
    </layout>
   </widget>

--- a/resource/curobo_rviz_panel.ui
+++ b/resource/curobo_rviz_panel.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>305</width>
+    <width>466</width>
     <height>170</height>
    </rect>
   </property>
@@ -16,84 +16,35 @@
   <widget class="QWidget" name="gridLayoutWidget">
    <property name="geometry">
     <rect>
-     <x>10</x>
+     <x>0</x>
      <y>10</y>
-     <width>283</width>
-     <height>150</height>
+     <width>461</width>
+     <height>151</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
+    <property name="leftMargin">
+     <number>5</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>5</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
     <property name="horizontalSpacing">
-     <number>2</number>
+     <number>3</number>
     </property>
     <property name="verticalSpacing">
-     <number>4</number>
+     <number>5</number>
     </property>
-    <item row="2" column="0">
-     <widget class="QLabel" name="label_3">
-      <property name="layoutDirection">
-       <enum>Qt::LeftToRight</enum>
-      </property>
+    <item row="2" column="3" colspan="2">
+     <widget class="QPushButton" name="confirmPushButton">
       <property name="text">
-       <string>Time dilation factor</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="margin">
-       <number>10</number>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="QSpinBox" name="spinBox_1">
-      <property name="maximum">
-       <number>10</number>
-      </property>
-      <property name="value">
-       <number>0</number>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="label_1">
-      <property name="layoutDirection">
-       <enum>Qt::LeftToRight</enum>
-      </property>
-      <property name="text">
-       <string>Max attemps</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="margin">
-       <number>10</number>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="QDoubleSpinBox" name="doubleSpinBox_1">
-      <property name="maximum">
-       <double>60.000000000000000</double>
-      </property>
-      <property name="singleStep">
-       <double>0.500000000000000</double>
-      </property>
-      <property name="value">
-       <double>0.000000000000000</double>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_2">
-      <property name="text">
-       <string>Timeout</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="margin">
-       <number>10</number>
+       <string>Confirm Changes</string>
       </property>
      </widget>
     </item>
@@ -110,12 +61,153 @@
       </property>
      </widget>
     </item>
-    <item row="3" column="0" colspan="2">
-     <widget class="QPushButton" name="confirmPushButton">
-      <property name="text">
-       <string>Confirm Changes</string>
+    <item row="1" column="4">
+     <widget class="QDoubleSpinBox" name="doubleSpinBox_4">
+      <property name="decimals">
+       <number>3</number>
+      </property>
+      <property name="maximum">
+       <double>50.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.025000000000000</double>
       </property>
      </widget>
+    </item>
+    <item row="0" column="3">
+     <widget class="QLabel" name="label_4">
+      <property name="text">
+       <string>Voxel size</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_2">
+      <property name="text">
+       <string>Timeout</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="label_1">
+      <property name="layoutDirection">
+       <enum>Qt::LeftToRight</enum>
+      </property>
+      <property name="text">
+       <string>Max attempts</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QSpinBox" name="spinBox_1">
+      <property name="maximum">
+       <number>10</number>
+      </property>
+      <property name="value">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="4">
+     <widget class="QDoubleSpinBox" name="doubleSpinBox_3">
+      <property name="maximum">
+       <double>50.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.020000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="3">
+     <widget class="QLabel" name="label_5">
+      <property name="text">
+       <string>Collision activation distance</string>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QDoubleSpinBox" name="doubleSpinBox_1">
+      <property name="maximum">
+       <double>60.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.500000000000000</double>
+      </property>
+      <property name="value">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_3">
+      <property name="layoutDirection">
+       <enum>Qt::LeftToRight</enum>
+      </property>
+      <property name="text">
+       <string>Time dilation factor</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="2">
+     <spacer name="horizontalSpacer">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>20</height>
+       </size>
+      </property>
+     </spacer>
     </item>
    </layout>
   </widget>

--- a/resource/curobo_rviz_panel.ui
+++ b/resource/curobo_rviz_panel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>466</width>
-    <height>149</height>
+    <height>178</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,7 +19,7 @@
      <x>0</x>
      <y>10</y>
      <width>461</width>
-     <height>131</height>
+     <height>161</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
@@ -39,7 +39,7 @@
      <number>3</number>
     </property>
     <property name="verticalSpacing">
-     <number>5</number>
+     <number>6</number>
     </property>
     <item row="3" column="1">
      <widget class="QDoubleSpinBox" name="doubleSpinBoxTimeDilationFactor">
@@ -126,8 +126,7 @@
      <widget class="QLabel" name="labelUpdateOnConfirm">
       <property name="font">
        <font>
-        <italic>true</italic>
-        <bold>true</bold>
+        <underline>true</underline>
         <strikeout>false</strikeout>
         <kerning>true</kerning>
        </font>
@@ -173,8 +172,7 @@
      <widget class="QLabel" name="labelUpdateOnChange">
       <property name="font">
        <font>
-        <italic>true</italic>
-        <bold>true</bold>
+        <underline>true</underline>
         <strikeout>false</strikeout>
         <kerning>true</kerning>
        </font>
@@ -236,8 +234,23 @@
       </property>
      </widget>
     </item>
-   </layout>
-  </widget>
+    <item row="4" column="4" colspan="2">
+     <widget class="QLabel" name="labelConfirmChangesMessage">
+      <property name="font">
+       <font>
+        <pointsize>8</pointsize>
+        <italic>true</italic>
+       </font>
+      </property>
+      <property name="text">
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    </layout>
+    </widget>
  </widget>
  <resources/>
  <connections/>

--- a/resource/curobo_rviz_panel.ui
+++ b/resource/curobo_rviz_panel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>305</width>
+    <height>170</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,10 +16,10 @@
   <widget class="QWidget" name="gridLayoutWidget">
    <property name="geometry">
     <rect>
-     <x>9</x>
-     <y>9</y>
-     <width>231</width>
-     <height>271</height>
+     <x>10</x>
+     <y>10</y>
+     <width>283</width>
+     <height>150</height>
     </rect>
    </property>
    <layout class="QGridLayout" name="gridLayout">
@@ -27,57 +27,8 @@
      <number>2</number>
     </property>
     <property name="verticalSpacing">
-     <number>3</number>
+     <number>4</number>
     </property>
-    <item row="0" column="1">
-     <widget class="QSpinBox" name="spinBox_1">
-      <property name="maximum">
-       <number>10</number>
-      </property>
-      <property name="value">
-       <number>1</number>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="QDoubleSpinBox" name="doubleSpinBox_1">
-      <property name="maximum">
-       <double>60.000000000000000</double>
-      </property>
-      <property name="singleStep">
-       <double>0.500000000000000</double>
-      </property>
-      <property name="value">
-       <double>5.000000000000000</double>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1">
-     <widget class="QDoubleSpinBox" name="doubleSpinBox_2">
-      <property name="maximum">
-       <double>1.000000000000000</double>
-      </property>
-      <property name="singleStep">
-       <double>0.100000000000000</double>
-      </property>
-      <property name="value">
-       <double>0.500000000000000</double>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_2">
-      <property name="text">
-       <string>Timeout</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-      </property>
-      <property name="margin">
-       <number>10</number>
-      </property>
-     </widget>
-    </item>
     <item row="2" column="0">
      <widget class="QLabel" name="label_3">
       <property name="layoutDirection">
@@ -94,6 +45,16 @@
       </property>
      </widget>
     </item>
+    <item row="0" column="1">
+     <widget class="QSpinBox" name="spinBox_1">
+      <property name="maximum">
+       <number>10</number>
+      </property>
+      <property name="value">
+       <number>0</number>
+      </property>
+     </widget>
+    </item>
     <item row="0" column="0">
      <widget class="QLabel" name="label_1">
       <property name="layoutDirection">
@@ -107,6 +68,52 @@
       </property>
       <property name="margin">
        <number>10</number>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QDoubleSpinBox" name="doubleSpinBox_1">
+      <property name="maximum">
+       <double>60.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.500000000000000</double>
+      </property>
+      <property name="value">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_2">
+      <property name="text">
+       <string>Timeout</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+      <property name="margin">
+       <number>10</number>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="QDoubleSpinBox" name="doubleSpinBox_2">
+      <property name="maximum">
+       <double>1.000000000000000</double>
+      </property>
+      <property name="singleStep">
+       <double>0.100000000000000</double>
+      </property>
+      <property name="value">
+       <double>0.000000000000000</double>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0" colspan="2">
+     <widget class="QPushButton" name="confirmPushButton">
+      <property name="text">
+       <string>Confirm Changes</string>
       </property>
      </widget>
     </item>

--- a/src/curobo_rviz.cpp
+++ b/src/curobo_rviz.cpp
@@ -10,6 +10,8 @@ namespace curobo_rviz
     , max_attempts_{0}
     , timeout_{0.0}
     , time_dilation_factor_{0.0}
+    , voxel_size_{0.0}
+    , collision_activation_distance_{0.0}
   {
     // Extend the widget with all attributes and children from UI file
     ui_->setupUi(this);
@@ -23,13 +25,12 @@ namespace curobo_rviz
       RCLCPP_INFO(node_->get_logger(), "service not available, waiting again...");
     }
 
-    // Prepare msg
-    msg_.data = true;
-
     // Connect SpinBox and DoubleSpinBox to slots
     connect(ui_->spinBox_1, SIGNAL(valueChanged(int)), this, SLOT(updateMaxAttempts(int)));
     connect(ui_->doubleSpinBox_1, SIGNAL(valueChanged(double)), this, SLOT(updateTimeout(double)));
     connect(ui_->doubleSpinBox_2, SIGNAL(valueChanged(double)), this, SLOT(updateTimeDilationFactor(double)));
+    connect(ui_->doubleSpinBox_3, SIGNAL(valueChanged(double)), this, SLOT(updateVoxelSize(double)));
+    connect(ui_->doubleSpinBox_4, SIGNAL(valueChanged(double)), this, SLOT(updateCollisionActivationDistance(double)));
   }
 
   RvizArgsPanel::~RvizArgsPanel()
@@ -38,13 +39,15 @@ namespace curobo_rviz
     void RvizArgsPanel::load(const rviz_common::Config &config)
     {
       Panel::load(config);
-      auto parameters = param_client_->get_parameters({"max_attempts", "timeout", "time_dilation_factor"});
+      auto parameters = param_client_->get_parameters({"max_attempts", "timeout", "time_dilation_factor", "voxel_size", "collision_activation_distance"});
       RCLCPP_INFO(node_->get_logger(), "Parameters received: %ld", parameters.size());
 
       // set initial values in UI to the values from the parameter server
       ui_->spinBox_1->setValue(parameters[0].as_int());
       ui_->doubleSpinBox_1->setValue(parameters[1].as_double());
       ui_->doubleSpinBox_2->setValue(parameters[2].as_double());
+      ui_->doubleSpinBox_3->setValue(parameters[3].as_double());
+      ui_->doubleSpinBox_4->setValue(parameters[4].as_double());
     }
 
     void RvizArgsPanel::save(rviz_common::Config config) const
@@ -53,24 +56,56 @@ namespace curobo_rviz
       config.mapSetValue("max_attempts", max_attempts_);
       config.mapSetValue("timeout", timeout_);
       config.mapSetValue("time_dilation_factor", time_dilation_factor_);
+      config.mapSetValue("voxel_size", voxel_size_);
+      config.mapSetValue("collision_activation_distance", collision_activation_distance_);
     }
 
     void RvizArgsPanel::updateMaxAttempts(int value)
     {
         max_attempts_ = value;
+        while (!param_client_->wait_for_service(std::chrono::seconds(1))) {
+            RCLCPP_INFO(node_->get_logger(), "service not available, waiting again...");
+        }
+        
+        // set parameters on parameter server
+        param_client_->set_parameters_atomically({rclcpp::Parameter("max_attempts", max_attempts_)});
         RCLCPP_INFO(node_->get_logger(), "Max attempts set to %d", max_attempts_);
     }
 
     void RvizArgsPanel::updateTimeout(double value)
     {
         timeout_ = value;
+        while (!param_client_->wait_for_service(std::chrono::seconds(1))) {
+            RCLCPP_INFO(node_->get_logger(), "service not available, waiting again...");
+        }
+        
+        // set parameters on parameter server
+        param_client_->set_parameters_atomically({rclcpp::Parameter("timeout", timeout_)});
         RCLCPP_INFO(node_->get_logger(), "Timeout set to %.2f", timeout_);
     }
 
     void RvizArgsPanel::updateTimeDilationFactor(double value)
     {
         time_dilation_factor_ = value;
+        while (!param_client_->wait_for_service(std::chrono::seconds(1))) {
+            RCLCPP_INFO(node_->get_logger(), "service not available, waiting again...");
+        }
+        
+        // set parameters on parameter server
+        param_client_->set_parameters_atomically({rclcpp::Parameter("time_dilation_factor", time_dilation_factor_)});
         RCLCPP_INFO(node_->get_logger(), "Time dilation factor set to %.2f", time_dilation_factor_);
+    }
+
+    void RvizArgsPanel::updateVoxelSize(double value)
+    {
+        voxel_size_ = value;
+        RCLCPP_INFO(node_->get_logger(), "Voxel size changed to %.2f", voxel_size_);
+    }
+
+    void RvizArgsPanel::updateCollisionActivationDistance(double value)
+    {
+        collision_activation_distance_ = value;
+        RCLCPP_INFO(node_->get_logger(), "Collision activation distance changed to %.2f", collision_activation_distance_);
     }
 
     void RvizArgsPanel::on_confirmPushButton_clicked()
@@ -81,14 +116,12 @@ namespace curobo_rviz
         }
         
         // set parameters on parameter server
-        param_client_->set_parameters_atomically({rclcpp::Parameter("max_attempts", max_attempts_),
-                                       rclcpp::Parameter("timeout", timeout_),
-                                       rclcpp::Parameter("time_dilation_factor", time_dilation_factor_)});
-        RCLCPP_INFO(node_->get_logger(), "Parameters set:\tmax_attempts: %d, timeout: %.2f, time_dilation_factor: %.2f", max_attempts_, timeout_, time_dilation_factor_);
+        param_client_->set_parameters_atomically({rclcpp::Parameter("voxel_size", voxel_size_),
+                                       rclcpp::Parameter("collision_activation_distance", collision_activation_distance_)});
+        RCLCPP_INFO(node_->get_logger(), "Parameters set:\voxel_size: %.2f, collision_activation_distance: %.2f", voxel_size_, collision_activation_distance_);
         
         // call Trigger service update_motion_gen_config
-        std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("update_motion_gen_config");
-        rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client = node->create_client<std_srvs::srv::Trigger>("update_motion_gen_config");
+        rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client = node_->create_client<std_srvs::srv::Trigger>("/curobo_gen_traj/update_motion_gen_config");
         auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
 
         while (!client->wait_for_service(std::chrono::seconds(1))) {
@@ -97,7 +130,7 @@ namespace curobo_rviz
         auto result = client->async_send_request(request);
         RCLCPP_INFO(node_->get_logger(), "Service call sent.");
         
-        if (rclcpp::spin_until_future_complete(node, result) == rclcpp::FutureReturnCode::SUCCESS) {
+        if (rclcpp::spin_until_future_complete(node_, result) == rclcpp::FutureReturnCode::SUCCESS) {
             RCLCPP_INFO(node_->get_logger(), "Service call successful.");
         } else {
             RCLCPP_ERROR(node_->get_logger(), "Service call failed.");

--- a/src/curobo_rviz.cpp
+++ b/src/curobo_rviz.cpp
@@ -75,10 +75,33 @@ namespace curobo_rviz
 
     void RvizArgsPanel::on_confirmPushButton_clicked()
     {
+        RCLCPP_INFO(node_->get_logger(), "Confirm button clicked.");
         while (!param_client_->wait_for_service(std::chrono::seconds(3))) {
             RCLCPP_INFO(node_->get_logger(), "service not available, waiting again...");
         }
-        RCLCPP_INFO(node_->get_logger(), "Confirm button clicked.");
+        
+        // set parameters on parameter server
+        param_client_->set_parameters_atomically({rclcpp::Parameter("max_attempts", max_attempts_),
+                                       rclcpp::Parameter("timeout", timeout_),
+                                       rclcpp::Parameter("time_dilation_factor", time_dilation_factor_)});
+        RCLCPP_INFO(node_->get_logger(), "Parameters set:\tmax_attempts: %d, timeout: %.2f, time_dilation_factor: %.2f", max_attempts_, timeout_, time_dilation_factor_);
+        
+        // call Trigger service update_motion_gen_config
+        std::shared_ptr<rclcpp::Node> node = rclcpp::Node::make_shared("update_motion_gen_config");
+        rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client = node->create_client<std_srvs::srv::Trigger>("update_motion_gen_config");
+        auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
+
+        while (!client->wait_for_service(std::chrono::seconds(1))) {
+            RCLCPP_INFO(node_->get_logger(), "service not available, waiting again...");
+        }
+        auto result = client->async_send_request(request);
+        RCLCPP_INFO(node_->get_logger(), "Service call sent.");
+        
+        if (rclcpp::spin_until_future_complete(node, result) == rclcpp::FutureReturnCode::SUCCESS) {
+            RCLCPP_INFO(node_->get_logger(), "Service call successful.");
+        } else {
+            RCLCPP_ERROR(node_->get_logger(), "Service call failed.");
+        }
     }
 
 } // curobo_rviz

--- a/src/curobo_rviz.cpp
+++ b/src/curobo_rviz.cpp
@@ -26,11 +26,11 @@ namespace curobo_rviz
     }
 
     // Connect SpinBox and DoubleSpinBox to slots
-    connect(ui_->spinBox_1, SIGNAL(valueChanged(int)), this, SLOT(updateMaxAttempts(int)));
-    connect(ui_->doubleSpinBox_1, SIGNAL(valueChanged(double)), this, SLOT(updateTimeout(double)));
-    connect(ui_->doubleSpinBox_2, SIGNAL(valueChanged(double)), this, SLOT(updateTimeDilationFactor(double)));
-    connect(ui_->doubleSpinBox_3, SIGNAL(valueChanged(double)), this, SLOT(updateVoxelSize(double)));
-    connect(ui_->doubleSpinBox_4, SIGNAL(valueChanged(double)), this, SLOT(updateCollisionActivationDistance(double)));
+    connect(ui_->spinBoxMaxAttempts, SIGNAL(valueChanged(int)), this, SLOT(updateMaxAttempts(int)));
+    connect(ui_->doubleSpinBoxTimeout, SIGNAL(valueChanged(double)), this, SLOT(updateTimeout(double)));
+    connect(ui_->doubleSpinBoxTimeDilationFactor, SIGNAL(valueChanged(double)), this, SLOT(updateTimeDilationFactor(double)));
+    connect(ui_->doubleSpinBoxVoxelSize, SIGNAL(valueChanged(double)), this, SLOT(updateVoxelSize(double)));
+    connect(ui_->doubleSpinBoxCollisionActivationDistance, SIGNAL(valueChanged(double)), this, SLOT(updateCollisionActivationDistance(double)));
   }
 
   RvizArgsPanel::~RvizArgsPanel()
@@ -43,11 +43,11 @@ namespace curobo_rviz
       RCLCPP_INFO(node_->get_logger(), "Parameters received: %ld", parameters.size());
 
       // set initial values in UI to the values from the parameter server
-      ui_->spinBox_1->setValue(parameters[0].as_int());
-      ui_->doubleSpinBox_1->setValue(parameters[1].as_double());
-      ui_->doubleSpinBox_2->setValue(parameters[2].as_double());
-      ui_->doubleSpinBox_3->setValue(parameters[3].as_double());
-      ui_->doubleSpinBox_4->setValue(parameters[4].as_double());
+      ui_->spinBoxMaxAttempts->setValue(parameters[0].as_int());
+      ui_->doubleSpinBoxTimeout->setValue(parameters[1].as_double());
+      ui_->doubleSpinBoxTimeDilationFactor->setValue(parameters[2].as_double());
+      ui_->doubleSpinBoxVoxelSize->setValue(parameters[3].as_double());
+      ui_->doubleSpinBoxCollisionActivationDistance->setValue(parameters[4].as_double());
     }
 
     void RvizArgsPanel::save(rviz_common::Config config) const


### PR DESCRIPTION
**What's in the PR ?**
- Retrieve parameters from node at launch
   - max_attempts
   - timeout
   - time_dilation_factor
   - voxel_size
   - collision_activation_distance
- Parameters are set in real-time:
   - max_attempts
   - timeout
   - time_dilation_factor
- Parameters are set after pressing the Confirm Button
   - voxel_size
   - collision_activation_distance

-> Since the implementation is made with `SyncParametersClient`, user must wait after curobo_gen_traj initialization before launching Rviz.

When parameters are set after pressing the Confirm, curobo_gen_traj reloads in a few seconds (and not the 15 seconds of usual warmup).

**What's next ?**
- Disable the button when setting world parameters (voxel_size, collision_activation_distance)
    -  Requires threading